### PR TITLE
add notices and license for third party Apachev2 packages

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,12 @@
 The MIT License (MIT)
 
 Copyright (c) 2013-2016 Atomic Jolt (http://www.atomicjolt.com)
+Copyright (c) 2017-Present Massachusetts Institute of Technology (https://www.mit.edu)
+
+All bundled software packages remain copyrighted / owned
+by their original copyright holders. No bundled packages
+were modified. The remainder of this work (`Content Player`)
+is licensed under the MIT license:
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE_ReactTapEventPlugin.txt
+++ b/LICENSE_ReactTapEventPlugin.txt
@@ -1,0 +1,13 @@
+Copyright 2016 Zilverline
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/NOTICES.md
+++ b/NOTICES.md
@@ -1,0 +1,8 @@
+Notice that this software bundle includes JavaScript packages
+bundled with Webpack. Those packages remain under
+the copyright and licenses of the original copyright holders
+-- no third-party packages have been modified.
+
+However, the authors of `Content Player` want to acknowledge that
+this bundle includes (in unmodified form):
+  - React-tap-event-plugin (Apache v2): https://www.npmjs.com/package/react-tap-event-plugin


### PR DESCRIPTION
- Adding a notices document to acknowledge third party software that gets bundled in, under Apache v2 license.
- Also including separate license file for `react-tap-event-plugin`.
- Updating license file with statement about third-party copyright holders maintaining their copyright.