### PR TITLE
add previous and next buttons to bottom of content player

### DIFF
--- a/client/js/components/book/page.jsx
+++ b/client/js/components/book/page.jsx
@@ -314,5 +314,7 @@ export class Page extends React.Component {
   }
 }
 
-export default connect(select,
-  { ...ContentActions, ...AnalyticsActions, ...ApplicationActions })(Page);
+export default connect(
+  select,
+  { ...ContentActions, ...AnalyticsActions, ...ApplicationActions }
+)(Page);

--- a/client/js/components/book/page.jsx
+++ b/client/js/components/book/page.jsx
@@ -5,6 +5,7 @@ import { Helmet }            from 'react-helmet';
 
 import * as ContentActions   from '../../actions/content';
 import * as AnalyticsActions from '../../actions/analytics';
+import * as ApplicationActions from '../../actions/application';
 // import assets                from '../../libs/assets';
 import getAVSrc              from '../../utils/audio_video_src';
 
@@ -42,7 +43,12 @@ export class Page extends React.Component {
     linkClick: React.PropTypes.func,
     buttonClick: React.PropTypes.func,
     openTranscript: React.PropTypes.func,
-    closeTranscript: React.PropTypes.func
+    closeTranscript: React.PropTypes.func,
+    selectPage: React.PropTypes.func,
+    tableOfContents: React.PropTypes.array,
+    params: React.PropTypes.shape({
+      pageId: React.PropTypes.string
+    })
   };
 
   componentDidMount() {
@@ -257,6 +263,39 @@ export class Page extends React.Component {
   render() {
     const lastModified = this.props.tocMeta.lastModified;
     const footerText = lastModified ? `CLIx release date: ${lastModified}` : undefined;
+
+    let previousButton;
+    let nextButton;
+    const { tableOfContents, params } = this.props;
+    if (tableOfContents && params) {
+      const currentPageIndex = _.findIndex(
+        tableOfContents,
+        item => item.id === params.pageId
+      );
+
+      if (currentPageIndex > -1 && currentPageIndex !== 0) {
+        // show Previous button
+        previousButton = (
+          <button
+            className="page-nav-button"
+            onClick={() => this.props.selectPage(tableOfContents[currentPageIndex - 1].id)}>
+            Previous
+          </button>
+        );
+      }
+
+      if (currentPageIndex > -1 && currentPageIndex !== tableOfContents.length - 1) {
+        // show Next button
+        nextButton = (
+          <button
+            className="page-nav-button"
+            onClick={() => this.props.selectPage(tableOfContents[currentPageIndex + 1].id)}>
+            Next
+          </button>
+        );
+      }
+    }
+
     return (
       <section className="c-page" tabIndex="-1" ref={(section) => { this.section = section; }}>
         <Helmet>
@@ -264,11 +303,13 @@ export class Page extends React.Component {
         </Helmet>
         {this.iframe(this.props)}
         <div className="c-release">
+          {previousButton}
           <span>{footerText}</span>
+          {nextButton}
         </div>
       </section>
     );
   }
 }
 
-export default connect(select, { ...ContentActions, ...AnalyticsActions })(Page);
+export default connect(select, { ...ContentActions, ...AnalyticsActions, ...ApplicationActions })(Page);

--- a/client/js/components/book/page.jsx
+++ b/client/js/components/book/page.jsx
@@ -278,7 +278,8 @@ export class Page extends React.Component {
         previousButton = (
           <button
             className="page-nav-button"
-            onClick={() => this.props.selectPage(tableOfContents[currentPageIndex - 1].id)}>
+            onClick={() => this.props.selectPage(tableOfContents[currentPageIndex - 1].id)}
+          >
             Previous
           </button>
         );
@@ -289,7 +290,8 @@ export class Page extends React.Component {
         nextButton = (
           <button
             className="page-nav-button"
-            onClick={() => this.props.selectPage(tableOfContents[currentPageIndex + 1].id)}>
+            onClick={() => this.props.selectPage(tableOfContents[currentPageIndex + 1].id)}
+          >
             Next
           </button>
         );
@@ -312,4 +314,5 @@ export class Page extends React.Component {
   }
 }
 
-export default connect(select, { ...ContentActions, ...AnalyticsActions, ...ApplicationActions })(Page);
+export default connect(select,
+  { ...ContentActions, ...AnalyticsActions, ...ApplicationActions })(Page);

--- a/client/js/components/book/page.jsx
+++ b/client/js/components/book/page.jsx
@@ -8,6 +8,7 @@ import * as AnalyticsActions from '../../actions/analytics';
 import * as ApplicationActions from '../../actions/application';
 // import assets                from '../../libs/assets';
 import getAVSrc              from '../../utils/audio_video_src';
+import { localizeStrings }      from '../../selectors/locale';
 
 const select = (state) => {
   const lang = state.content.tocMeta.language;
@@ -17,7 +18,8 @@ const select = (state) => {
     tocMeta:          state.content.tocMeta,
     contentPath:      state.content.contentPath,
     pageFocus:        state.application.pageFocus,
-    locale:           lang
+    locale:           lang,
+    localizedStrings: localizeStrings(state)
 
   };
 };
@@ -25,6 +27,8 @@ const select = (state) => {
 export class Page extends React.Component {
 
   static propTypes = {
+    // User facing strings of the language specified by the 'locale' setting
+    localizedStrings: React.PropTypes.object,
     tocMeta: React.PropTypes.shape({
       gradeUnit: React.PropTypes.string,
       subjectLesson: React.PropTypes.string,
@@ -280,7 +284,7 @@ export class Page extends React.Component {
             className="page-nav-button"
             onClick={() => this.props.selectPage(tableOfContents[currentPageIndex - 1].id)}
           >
-            Previous
+            {this.props.localizedStrings.footer.previous}
           </button>
         );
       }
@@ -292,7 +296,7 @@ export class Page extends React.Component {
             className="page-nav-button"
             onClick={() => this.props.selectPage(tableOfContents[currentPageIndex + 1].id)}
           >
-            Next
+            {this.props.localizedStrings.footer.next}
           </button>
         );
       }

--- a/client/js/components/book/page.spec.jsx
+++ b/client/js/components/book/page.spec.jsx
@@ -35,6 +35,12 @@ describe('page', () => {
       tableOfContents: [{ id:'1' }, { id:'2' }, { id:'3' }],
       params: {
         pageId: '1'
+      },
+      localizedStrings: {
+        footer: {
+          next: 'Next',
+          previous: 'Previous'
+        }
       }
     };
 

--- a/client/js/components/book/page.spec.jsx
+++ b/client/js/components/book/page.spec.jsx
@@ -28,4 +28,25 @@ describe('page', () => {
     const result = page.iframe(props);
     expect(result.type).toEqual('div');
   });
+
+  it('renders navigation buttons', () => {
+    const pageProps = {
+      tocMeta: {},
+      tableOfContents: [{ id:'1' }, { id:'2' }, { id:'3' }],
+      params: {
+        pageId: '1'
+      }
+    };
+
+    page = TestUtils.renderIntoDocument(<Page {...pageProps} />);
+    expect(TestUtils.scryRenderedDOMComponentsWithClass(page, 'page-nav-button').length).toEqual(1);
+
+    pageProps.params.pageId = '2';
+    page = TestUtils.renderIntoDocument(<Page {...pageProps} />);
+    expect(TestUtils.scryRenderedDOMComponentsWithClass(page, 'page-nav-button').length).toEqual(2);
+
+    pageProps.params.pageId = '3';
+    page = TestUtils.renderIntoDocument(<Page {...pageProps} />);
+    expect(TestUtils.scryRenderedDOMComponentsWithClass(page, 'page-nav-button').length).toEqual(1);
+  });
 });

--- a/client/js/locales/en.js
+++ b/client/js/locales/en.js
@@ -4,8 +4,8 @@ export default {
       activityList: 'Activity List'
     },
     footer: {
-      next: 'Next',
-      previous: 'Previous'
+      next: 'Next', // Next page button in the footer
+      previous: 'Previous' // Previous page button in the footer
     }
   }
 };

--- a/client/js/locales/en.js
+++ b/client/js/locales/en.js
@@ -1,7 +1,11 @@
 export default {
   en: {
     sidebar: {
-      activityList: "Activity List"
+      activityList: 'Activity List'
+    },
+    footer: {
+      next: 'Next',
+      previous: 'Previous'
     }
   }
 };

--- a/client/js/locales/hi.js
+++ b/client/js/locales/hi.js
@@ -2,6 +2,10 @@ export default {
   hi: {
     sidebar:{
       activityList: "गतिविधीयों की सूची" // Sidebar title
+    },
+    footer: {
+      next: 'आगामी',  // Next page button in the footer
+      previous: 'पिछला'  // Previous page button in the footer
     }
   }
 };

--- a/client/js/locales/hi.js
+++ b/client/js/locales/hi.js
@@ -4,8 +4,8 @@ export default {
       activityList: "गतिविधीयों की सूची" // Sidebar title
     },
     footer: {
-      next: 'आगामी',  // Next page button in the footer
-      previous: 'पिछला'  // Previous page button in the footer
+      next: 'आगामी', // Next page button in the footer
+      previous: 'पिछला' // Previous page button in the footer
     }
   }
 };

--- a/client/js/locales/te.js
+++ b/client/js/locales/te.js
@@ -4,8 +4,8 @@ export default {
       activityList: "కార్యాచరణ జాబితా" // Sidebar title
     },
     footer: {
-      next: 'తరువాత',  // Next page button in the footer
-      previous: 'మునుపటి'  // Previous page button in the footer
+      next: 'తరువాత', // Next page button in the footer
+      previous: 'మునుపటి' // Previous page button in the footer
     }
   }
 };

--- a/client/js/locales/te.js
+++ b/client/js/locales/te.js
@@ -2,6 +2,10 @@ export default {
   te: {
     sidebar:{
       activityList: "కార్యాచరణ జాబితా" // Sidebar title
+    },
+    footer: {
+      next: 'తరువాత',  // Next page button in the footer
+      previous: 'మునుపటి'  // Previous page button in the footer
     }
   }
 };


### PR DESCRIPTION
Will definitely have to be styled. Currently looks like this:

<img width="283" alt="captura de pantalla 2017-11-21 a la s 4 01 25 pm" src="https://user-images.githubusercontent.com/4930129/33096506-448b6a92-ced5-11e7-9693-f7917032aa4f.png">

The first page should have only the `Next` button, the last page should only have the `Previous` button, and all other pages should have both buttons.

You can test this outside of unplatform with `yarn hot` and copying an unpacked ePub into the `build/dev` folder:

```
build
   - dev
      - lesson 1
         - META-INF
         - OEBPS
```

And then opening `http://localhost:8080?epubUrl=lesson%201` (assuming that you are running content player on port `8080`)