### PR TITLE
remove pink bar indicating focus shift to iframe

### DIFF
--- a/client/styles/components/_components.page.scss
+++ b/client/styles/components/_components.page.scss
@@ -7,9 +7,9 @@
   border-left-style: solid;
   border-left-color: hsla(316, 77%, 37%, 0);
 
-  &:focus { // focusing on section
-    border-left-color: hsla(316, 77%, 77%, 1);
-  }
+  // &:focus { // focusing on section
+  //   border-left-color: hsla(316, 77%, 77%, 1);
+  // }
 
   iframe {
     display: block;


### PR DESCRIPTION
Interferes with some of the converted ePubs we're getting from the content teams, because there isn't a margin / padding on the left of the content. Per Mary Z, it's okay to remove the visual indicator (focus still shifts to the iframe).